### PR TITLE
Update to use allow list rather than whitelist

### DIFF
--- a/docs/Boycott.md
+++ b/docs/Boycott.md
@@ -75,7 +75,7 @@ This list also features companies that:
 - The list is still being verified. **There may be false positives,** please [create issues](https://github.com/vshymanskyy/StandWithUkraine/issues/new) to fix them
 - Companies will be removed from the list if there's copmelling evidence of them suspending operations in Russia
 
-## Whitelist (closing offices, suspending operations, etc.)
+## Allow list (closing offices, suspending operations, etc.)
 - Revolut
 - Luxoft
 - EPAM Systems (still unclear, their communication is lacking)


### PR DESCRIPTION
Consider using allow list rather than a whitelist.

> However, there's an issue with the terminology. It only makes sense if you equate white with 'good, permitted, safe' and black with 'bad, dangerous, forbidden'. There are some obvious problems with this.

Further reading: https://www.ncsc.gov.uk/blog-post/terminology-its-not-black-and-white