### PR TITLE
Make banners responsive for better small-screen display

### DIFF
--- a/banner-direct-single.svg
+++ b/banner-direct-single.svg
@@ -51,6 +51,28 @@ svg|a:hover > text, svg|a:active > text {
   font-size: 16px;
   fill: black;
 }
+
+.mobile-only {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  svg > * {
+    display: none;
+  }
+
+  svg > rect, .mobile, .mobile-only {
+    display: inherit;
+  }
+
+  svg|a text {
+    font-size: 40px;
+  }
+
+  .message, .hashtag {
+    font-size: 30px;
+  }
+}
   </style>
   
   <rect x="0" y="0" width="100%" height="100%" class="flag-yellow"/>
@@ -73,8 +95,19 @@ svg|a:hover > text, svg|a:active > text {
     </a>
   </g>
 
-  <text x="1020" y="180" class="hashtag"
-        text-anchor="end">
+  <g class="mobile-only">
+    <text x="0" y="25" font-size="20" dy="0" class="message">
+      <tspan x="20" dy=".6em">Russia has invaded Ukraine and already <tspan font-weight="bold">killed thousands of civilians.</tspan></tspan>
+      <tspan x="20" dy="1.35em">The death toll is still counting. It is a war and we need your help.</tspan>
+    </text>
+
+    <a href="https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md">
+        <rect x="340" y="120" width="360" height="70" rx="10" class="button" />
+        <text x="520" y="155" dominant-baseline="middle" text-anchor="middle">Support Ukraine</text>
+    </a>
+  </g>
+
+  <text x="1020" y="180" class="hashtag mobile" text-anchor="end">
       #StandWithUkraine
   </text>
 

--- a/banner-direct.svg
+++ b/banner-direct.svg
@@ -51,6 +51,28 @@ svg|a:hover > text, svg|a:active > text {
   font-size: 16px;
   fill: black;
 }
+
+.mobile-only {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  svg > * {
+    display: none;
+  }
+
+  svg > rect, .mobile, .mobile-only {
+    display: inherit;
+  }
+
+  svg|a text {
+    font-size: 40px;
+  }
+
+  .message, .hashtag {
+    font-size: 30px;
+  }
+}
   </style>
   
   <rect x="0" y="0" width="100%" height="100%" class="flag-yellow"/>
@@ -65,17 +87,24 @@ svg|a:hover > text, svg|a:active > text {
 
   <g>
     <a href="https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md">
-        <rect x="40"  y="135" width="240" height="40" rx="6" class="button"/>
-        <text x="160" y="155"
-            dominant-baseline="middle"
-            font-weight="bold"
-            text-anchor="middle">Support Ukraine</text>
+        <rect x="40" y="135" width="240" height="40" rx="6" class="button"/>
+        <text x="160" y="155" dominant-baseline="middle" text-anchor="middle">Support Ukraine</text>
+    </a>
+  </g>
+  
+  <g class="mobile-only">
+    <text x="0" y="25" font-size="20" dy="0" class="message">
+      <tspan x="20" dy=".6em">Russia has invaded Ukraine and already killed thousands of civilians.</tspan>
+      <tspan x="20" dy="1.35em">The death toll is still counting. It is a war and we need your help.</tspan>
+    </text>
+
+    <a href="https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md">
+        <rect x="340" y="120" width="360" height="70" rx="10" class="button" />
+        <text x="520" y="155" dominant-baseline="middle" text-anchor="middle">Support Ukraine</text>
     </a>
   </g>
 
-  <text x="1020" y="180" class="hashtag"
-        text-anchor="end">
+  <text x="1020" y="180" class="hashtag mobile" text-anchor="end">
       #StandWithUkraine
   </text>
-
 </svg>

--- a/banner-personal-page.svg
+++ b/banner-personal-page.svg
@@ -51,6 +51,28 @@ svg|a:hover > text, svg|a:active > text {
   font-size: 16px;
   fill: black;
 }
+
+.mobile-only {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  svg > * {
+    display: none;
+  }
+
+  svg > rect, .mobile, .mobile-only {
+    display: inherit;
+  }
+
+  svg|a text {
+    font-size: 40px;
+  }
+
+  .message, .hashtag {
+    font-size: 30px;
+  }
+}
   </style>
   
   <rect x="0" y="0" width="100%" height="100%" class="flag-yellow"/>
@@ -73,8 +95,19 @@ svg|a:hover > text, svg|a:active > text {
     </a>
   </g>
 
-  <text x="1020" y="180" class="hashtag"
-        text-anchor="end">
+  <g class="mobile-only">
+    <text x="0" y="25" font-size="20" dy="0" class="message">
+      <tspan x="20" dy=".6em">Russia has invaded Ukraine and already <tspan font-weight="bold">killed thousands of civilians.</tspan></tspan>
+      <tspan x="20" dy="1.35em">The death toll is still counting. It is a war and we need your help.</tspan>
+    </text>
+
+    <a href="https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md">
+        <rect x="340" y="120" width="360" height="70" rx="10" class="button" />
+        <text x="520" y="155" dominant-baseline="middle" text-anchor="middle">Support Ukraine</text>
+    </a>
+  </g>
+
+  <text x="1020" y="180" class="hashtag mobile" text-anchor="end">
       #StandWithUkraine
   </text>
 

--- a/banner.svg
+++ b/banner.svg
@@ -51,6 +51,28 @@ svg|a:hover > text, svg|a:active > text {
   font-size: 16px;
   fill: black;
 }
+
+.mobile-only {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  svg > * {
+    display: none;
+  }
+
+  svg > rect, .mobile, .mobile-only {
+    display: inherit;
+  }
+
+  svg|a text {
+    font-size: 40px;
+  }
+
+  .message, .hashtag {
+    font-size: 30px;
+  }
+}
   </style>
   
   <rect x="0" y="0" width="100%" height="100%" class="flag-yellow"/>
@@ -80,8 +102,24 @@ svg|a:hover > text, svg|a:active > text {
     </a>
   </g>
 
-  <text x="1020" y="180" class="hashtag"
-        text-anchor="end">
+  <g class="mobile-only">
+    <text x="0" y="25" font-size="20" dy="0" class="message">
+      <tspan x="20" dy=".6em">Russia has invaded Ukraine and already <tspan font-weight="bold">killed thousands of civilians.</tspan></tspan>
+      <tspan x="20" dy="1.35em">The death toll is still counting. It is a war and we need your help.</tspan>
+    </text>
+
+    <a href="https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md">
+        <rect x="15"  y="120" width="330" height="70" rx="10" class="button"/>
+        <text x="180" y="155" dominant-baseline="middle" text-anchor="middle">Read more</text>
+    </a>
+
+    <a href="https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md">
+        <rect x="365" y="120" width="330" height="70" rx="10" class="button" />
+        <text x="530" y="155" dominant-baseline="middle" text-anchor="middle">Support Ukraine</text>
+    </a>
+  </g>
+
+  <text x="1020" y="180" class="hashtag mobile" text-anchor="end">
       #StandWithUkraine
   </text>
 

--- a/banner2-direct.svg
+++ b/banner2-direct.svg
@@ -51,6 +51,28 @@ svg|a:hover > text, svg|a:active > text {
   font-size: 16px;
   fill: black;
 }
+
+.mobile-only {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  svg > * {
+    display: none;
+  }
+
+  svg > rect, .mobile, .mobile-only {
+    display: inherit;
+  }
+
+  svg|a text {
+    font-size: 40px;
+  }
+
+  .message, .hashtag {
+    font-size: 30px;
+  }
+}
   </style>
   
   <rect x="0" y="0" width="100%" height="100%" class="flag-yellow"/>
@@ -64,16 +86,25 @@ svg|a:hover > text, svg|a:active > text {
 
   <g>
     <a href="https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md">
-        <rect x="40"  y="135" width="240" height="40" rx="6" class="button"/>
-        <text x="160" y="155"
-            dominant-baseline="middle"
-            font-weight="bold"
-            text-anchor="middle">Support Ukraine</text>
+      <rect x="40" y="135" width="240" height="40" rx="6" class="button"/>
+      <text x="160" y="155" dominant-baseline="middle" font-weight="bold" text-anchor="middle">Support Ukraine</text>
     </a>
   </g>
 
-  <text x="1020" y="180" class="hashtag"
-        text-anchor="end">
+  <g class="mobile-only">
+    <text x="0" y="25" font-size="20" dy="0" class="message">
+      <tspan x="20" dy=".6em">Russia has invaded Ukraine and already <tspan font-weight="bold">killed thousands of civilians.</tspan>
+      </tspan>
+      <tspan x="20" dy="1.35em">The death toll is still counting. It is a war and we need your help.</tspan>
+    </text>
+
+    <a href="https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md">
+      <rect x="340" y="120" width="360" height="70" rx="10" class="button" />
+      <text x="520" y="155" dominant-baseline="middle" text-anchor="middle">Support Ukraine</text>
+    </a>
+  </g>
+
+  <text x="1020" y="180" class="hashtag mobile" text-anchor="end">
       #StandWithUkraine
   </text>
 

--- a/banner2-no-action.svg
+++ b/banner2-no-action.svg
@@ -51,6 +51,28 @@ svg|a:hover > text, svg|a:active > text {
   font-size: 16px;
   fill: black;
 }
+
+.mobile-only {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  svg > * {
+    display: none;
+  }
+
+  svg > rect, .mobile, .mobile-only {
+    display: inherit;
+  }
+
+  svg|a text {
+    font-size: 40px;
+  }
+
+  .message, .hashtag {
+    font-size: 30px;
+  }
+}
   </style>
   
   <rect x="0" y="0" width="100%" height="100%" class="flag-yellow"/>
@@ -61,9 +83,14 @@ svg|a:hover > text, svg|a:active > text {
     <tspan x="20" dy="1.2em">Russia has invaded Ukraine and already <tspan font-weight="bold">killed thousands of civilians, including more than 85 children</tspan>.</tspan>
     <tspan x="20" dy="1.2em">The death toll is still counting. It is a war and we need your help. Let's stand together against the Russian regime.</tspan>
   </text>
+  
+  <text x="0" y="25" font-size="20" dy="0" class="message mobile-only">
+    <tspan x="20" dy="0.6em">Russia has invaded Ukraine and already <tspan font-weight="bold">killed thousands of civilians.</tspan></tspan>
+    <tspan x="20" dy="1.4em">The death toll is still counting. It is a war and we need your help.</tspan>
+    <tspan x="20" dy="2.1em" class="hashtag">Let's stand together against the Russian regime.</tspan>
+  </text>
 
-  <text x="1020" y="180" class="hashtag"
-        text-anchor="end">
+  <text x="1020" y="180" class="hashtag mobile" text-anchor="end">
       #StandWithUkraine
   </text>
 

--- a/banner2.svg
+++ b/banner2.svg
@@ -51,6 +51,28 @@ svg|a:hover > text, svg|a:active > text {
   font-size: 16px;
   fill: black;
 }
+
+.mobile-only {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  svg > * {
+    display: none;
+  }
+
+  svg > rect, .mobile, .mobile-only {
+    display: inherit;
+  }
+
+  svg|a text {
+    font-size: 40px;
+  }
+
+  .message, .hashtag {
+    font-size: 30px;
+  }
+}
   </style>
   
   <rect x="0" y="0" width="100%" height="100%" class="flag-yellow"/>
@@ -79,8 +101,24 @@ svg|a:hover > text, svg|a:active > text {
     </a>
   </g>
 
-  <text x="1020" y="180" class="hashtag"
-        text-anchor="end">
+  <g class="mobile-only">
+    <text x="0" y="25" font-size="20" dy="0" class="message">
+      <tspan x="20" dy=".6em">Russia has invaded Ukraine and already <tspan font-weight="bold">killed thousands of civilians.</tspan></tspan>
+      <tspan x="20" dy="1.35em">The death toll is still counting. It is a war and we need your help.</tspan>
+    </text>
+
+    <a href="https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md">
+        <rect x="15"  y="120" width="330" height="70" rx="10" class="button"/>
+        <text x="180" y="155" dominant-baseline="middle" text-anchor="middle">Read more</text>
+    </a>
+
+    <a href="https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md">
+        <rect x="365" y="120" width="330" height="70" rx="10" class="button" />
+        <text x="530" y="155" dominant-baseline="middle" text-anchor="middle">Support Ukraine</text>
+    </a>
+  </g>
+
+  <text x="1020" y="180" class="hashtag mobile" text-anchor="end">
       #StandWithUkraine
   </text>
 


### PR DESCRIPTION
The text on the current banners gets hard to read on small screens, but SVG supports CSS `@media` queries that can allow different styling on small screens.

This PR shows a slightly reduced content at a larger font size when the SVG is smaller than 600px wide.