### PR TITLE
Make the banner text slightly shorter to fit GitHub's screen width

### DIFF
--- a/banner-personal-page.svg
+++ b/banner-personal-page.svg
@@ -83,7 +83,7 @@ svg|a:hover > text, svg|a:active > text {
   <text x="0" y="25" font-size="20" dy="0" class="message">
     <tspan x="20" dy=".6em" >This is a personal profile of an open source software contributor from Ukraine.</tspan>
     <tspan x="20" dy="1.2em">Russia has invaded Ukraine and already <tspan font-weight="bold">killed over 3000 civilians, including more than 105 children</tspan>.</tspan>
-    <tspan x="20" dy="1.2em">The death toll continues climbing. It is a war and we need your help. Let's stand together against the Russian regime.</tspan>
+    <tspan x="20" dy="1.2em">The death toll continues climbing. It's a war and we need your help. Let's stand together against the Russian regime.</tspan>
   </text>
 
   <g>
@@ -99,7 +99,7 @@ svg|a:hover > text, svg|a:active > text {
   <g class="mobile-only">
     <text x="0" y="25" font-size="20" dy="0" class="message">
       <tspan x="20" dy=".6em">Russia has invaded Ukraine and already <tspan font-weight="bold">killed over 3000 civilians.</tspan></tspan>
-      <tspan x="20" dy="1.35em">The death toll continues climbing. It is a war and we need your help.</tspan>
+      <tspan x="20" dy="1.35em">The death toll continues climbing. It's a war and we need your help.</tspan>
     </text>
 
     <a href="https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md">


### PR DESCRIPTION
Last change I PR'd made the text too wide so it barely doesn't fit anymore. Hopefully this fixes it.

![image](https://user-images.githubusercontent.com/1935960/159351907-72aac112-a554-4b94-a01e-ace621315715.png)
