### PR TITLE
Safari image embed fixes

### DIFF
--- a/banner2-direct.svg
+++ b/banner2-direct.svg
@@ -4,6 +4,7 @@
 
 svg {
   font-family: Helvetica, Arial, sans-serif;
+  text-rendering: geometricPrecision;
 }
 svg|a:link, svg|a:visited {
   cursor: pointer;
@@ -50,12 +51,12 @@ svg|a:link, svg|a:visited {
     <rect x="0" y="0" width="100%" height="110px" class="flag-blue"/>
 
     <text x="0" y="25" class="message">
-      <tspan x="20" dy="1.15em">Russia has invaded Ukraine and already killed tens of thousands of civilians, with many more raped or tortured.</tspan>
-      <tspan x="20" dy="1.35em">The death toll keeps climbing. It's a <tspan font-weight="bold">genocide</tspan>. We need your help. Let's fight back against the Russian regime.</tspan>
+      <tspan x="25" dy="1.15em">Russia has invaded Ukraine and already killed tens of thousands of civilians, with many more raped or tortured.</tspan>
+      <tspan x="25" dy="1.35em">The death toll keeps climbing. It's a <tspan font-weight="bold">genocide</tspan>. We need your help. Let's fight back against the Russian regime.</tspan>
     </text>
     <text x="0" y="25" class="message mobile-only">
-      <tspan x="20" dy=".7em">Russia has invaded Ukraine and already killed tens of thousands of civilians,</tspan>
-      <tspan x="20" dy="1.2em">with many more raped or tortured. It's a <tspan font-weight="bold">genocide</tspan>. We need your help.</tspan>
+      <tspan x="25" dy=".7em">Russia has invaded Ukraine and already killed tens of thousands of civilians,</tspan>
+      <tspan x="25" dy="1.2em">with many more raped or tortured. It's a <tspan font-weight="bold">genocide</tspan>. We need your help.</tspan>
     </text>
 
     <text x="50%" y="78.5%" dominant-baseline="middle" text-anchor="middle" class="call">

--- a/banner2-direct.svg
+++ b/banner2-direct.svg
@@ -50,16 +50,16 @@ svg|a:link, svg|a:visited {
     <rect x="0" y="0" width="100%" height="110px" class="flag-blue"/>
 
     <text x="0" y="25" class="message">
-      <tspan x="25" dy="1.15em">Russia has invaded Ukraine and already killed tens of thousands of civilians, with many more raped or tortured.</tspan>
-      <tspan x="25" dy="1.35em">The death toll keeps climbing. It's a <tspan font-weight="bold">genocide</tspan>. We need your help. Let's fight back against the Russian regime.</tspan>
+      <tspan x="20" dy="1.15em">Russia has invaded Ukraine and already killed tens of thousands of civilians, with many more raped or tortured.</tspan>
+      <tspan x="20" dy="1.35em">The death toll keeps climbing. It's a <tspan font-weight="bold">genocide</tspan>. We need your help. Let's fight back against the Russian regime.</tspan>
     </text>
     <text x="0" y="25" class="message mobile-only">
-      <tspan x="25" dy=".7em">Russia has invaded Ukraine and already killed tens of thousands of civilians,</tspan>
-      <tspan x="25" dy="1.2em">with many more raped or tortured. It's a <tspan font-weight="bold">genocide</tspan>. We need your help.</tspan>
+      <tspan x="20" dy=".7em">Russia has invaded Ukraine and already killed tens of thousands of civilians,</tspan>
+      <tspan x="20" dy="1.2em">with many more raped or tortured. It's a <tspan font-weight="bold">genocide</tspan>. We need your help.</tspan>
     </text>
 
     <text x="50%" y="78.5%" dominant-baseline="middle" text-anchor="middle" class="call">
-      Help Ukraine Now <tspan class="arrow">➔</tspan>
+      Help Ukraine Now <tspan dominant-baseline="middle" class="arrow">➔</tspan>
     </text>
   </a>
 


### PR DESCRIPTION
A few fixes for issues that @[vadimdemedes](https://github.com/vadimdemedes) pointed out, that are only reproducible in Safari through an IMG embed, which renders SVG slightly differently than if you open it directly 🤷‍♂️ 

- Added a property that makes the arrow properly centered.
- Enabled `text-sizing: geometricPrecision` which makes Safari properly size fonts instead of being "jumpy", fixing the issue of the text not fitting at certain widths.

![](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/c9a2336f645b658849d80e3a3073a56eaac9bc85/banner2-direct.svg)