### PR TITLE
Removed Société Générale that canceled operations in russia

### DIFF
--- a/docs/Boycott.md
+++ b/docs/Boycott.md
@@ -126,7 +126,6 @@ This list also features companies that:
 
 🇦🇹 Raiffeisen
 🇮🇹 Unicredit
-🇫🇷 Société Générale
 🇺🇸 Citi
 🇫🇷 Auchan
 


### PR DESCRIPTION
proof https://www.lemonde.fr/economie/article/2022/04/11/guerre-en-ukraine-societe-generale-cesse-ses-activites-en-russie_6121654_3234.html