### PR TITLE
fix: added an alternate name for yclients

### DIFF
--- a/docs/Boycott.md
+++ b/docs/Boycott.md
@@ -17,7 +17,7 @@ Everything in **`.ru`, `.su`, `.by`** domains should be avoided (most probably).
 0. **Synopsys**
 0. **T-Systems CIS**
 0. **Tilda**
-0. **Yclients**
+0. **Yclients & Altegio (alteg.io)**
 0. 1C Company
 0. Advego
 0. AmoCRM


### PR DESCRIPTION
If you check the [yclients.com](https://yclients.com) & [alteg.io](https://alteg.io) website, you will find no difference except naming. 

They just changed the name, and **a lot of business from Ukraine** is still working with the Russian service during the Russian army bombed Ukrainian cities. So maybe somebody from the community can share this with the media.

They circumvent sanctions by changing their name and registering a new company in "friendly" Hungary. BUT it's still a Russian mather company.