### PR TITLE
Replace URL for Come Back Alive

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,7 @@ These funds will be used to finance local humanitarian relief, as well as Ukrain
 Below is a list of non-profits that currently operate in Ukraine.
 Please opt-in for a monthly payment, if possible.
 
-- 💵 [**Come Back Alive**](https://www.comebackalive.in.ua/donate) — funds used to buy equipment for frontline soldiers as well as territorial defense units.
+- 💵 [**Come Back Alive**](https://savelife.in.ua/en/donate-en/) — funds used to buy equipment for frontline soldiers as well as territorial defense units.
 - 💵 [**Serhiy Prytula Charity Foundation**](https://prytulafoundation.org/en) — funds used to buy **non-lethal** equipment and transport vehicles for the military and to provide humanitarian aid to Ukrainians affected by the war.
 - 💵 [**Hospitallers Battalion**](https://www.hospitallers.life/needs-hospitallers) — funds used to buy supplies and equipment for medics on the frontline.
 - 💵 [**Ukrainian Red Cross**](https://redcross.org.ua/en/donate/) — provides humanitarian relief to Ukrainians affected by the war.


### PR DESCRIPTION
It seems that The Come Back Alive Fund has deprecated it's site on [comebackalive.in.ua](https://www.comebackalive.in.ua/) in favor of their older site at [savelife.in.ua](https://savelife.in.ua/) . 

Although the deprecated site's [donations page](https://www.comebackalive.in.ua/donate) is still up, I propose to replace the URL of Come Back Alive's entry with one from their primary domain, which is: [https://savelife.in.ua/en/donate-en/](https://savelife.in.ua/en/donate-en/) . 

The [donations page](https://savelife.in.ua/en/donate-en/) on the CBA's primary domain also has some advantages compared to the [one](https://www.comebackalive.in.ua/donate) currently on the list: 

- it offers subscriptions
- it has clear separation between donations to The Armed Forces and donations in support of The Fund
- it has clearly visible link to [reports page](https://savelife.in.ua/en/reports-en/) 

Thank you. 

A screenshot of the deprecation message: 

![comebackalive in ua](https://user-images.githubusercontent.com/90060353/201486383-236b8e55-f30b-4bde-b667-9e3ed7cd8c36.png)