### PR TITLE
Update Boycott.md

### DIFF
--- a/docs/Boycott.md
+++ b/docs/Boycott.md
@@ -82,6 +82,7 @@ Everything in **`.ru`, `.su`, `.by`** domains should be avoided (most probably).
 0. Skillbox
 0. Skyeng
 0. TamoSoft
+0. Telegram
 0. Unisender
 0. Utmstat
 0. VK (VKontakte)
@@ -110,7 +111,6 @@ This list also features companies that:
 # Other companies to avoid
 
 🇬🇧 Unilever  
-🇫🇷 Danone  
 🇨🇭 Nestlé  
 🇺🇸 Mondelez  
 🇺🇸 Colgate-Palmolive  


### PR DESCRIPTION
- added telegram as it is russian and has close ties to russia (financed by ru hedge fonds, banks etc; offices are located in russia, most of emlpoyes are russians)

- removed Danone as per its statement https://leave-russia.org/uk/danone