### PR TITLE
Add Druk Army

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,8 @@ Please opt-in for a monthly payment, if possible.
 - 💵 [**Sprava Hromad**](https://spgr.org.ua/en/donate/) — funds are being used to buy armored and transport vehicles, medium and heavy trucks, large UAV systems, communication systems, etc. for frontline UAF divisions.
 - 💵 [**Opir**](https://opir.org/) - focuses on providing individual items and equipment to fighters at the platoon and group levels.
 - 💵 [**Dignitas Ukraine Inc**](https://dignitas.fund/) — Supporting people of Ukraine through the provision of essential humanitarian supplies, technology, training initiatives and expert guidance [501(c)3, Tax ID 92-3194330].
-
+- 💵 [**DrukArmy**](https://drukarmy.org.ua/) — DrukArmy is a community of international volunteers who create everything that can be useful for the Armed Forces of Ukraine.
+- 
 ### Other ways to help
 
 - 🗣 Don't be silent:


### PR DESCRIPTION
Share about volounter organisation Druk Army <https://drukarmy.org.ua/>.

Support Army by:
- Print details with personal 3D printer
- Join developers and contribute to support the platform to deliver 10 tons of goods to the front line