### PR TITLE
Add StitchAPI to the projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,5 +74,6 @@ This repository contains **Readme Banners** (and some useful docs) that can be u
 - [Stacks.js](https://github.com/stacksjs) - Develop modern clouds, apps & framework-agnostic libraries, faster
 - [django-content-settings](https://github.com/occipital/django-content-settings) - The most advanced admin editable setting for Django
 - [aProxyRelay](https://github.com/my-dev-app/proxy-relay) - an asynchronous rotating proxy request library designed for easy data retrieval using various (tested) proxy servers.
+- [StitchAPI](https://github.com/rejifald/StitchAPI) - A typed, streaming-first TypeScript toolkit for calling, validating and composing APIs — an agent-native replacement for fetch
 - [**...and more than 23000 others**](https://github.com/search?q=vshymanskyy%2FStandWithUkraine&type=code)
 


### PR DESCRIPTION
StitchAPI displays the Stand With Ukraine banner in its README, so I'd like to add it to the list of projects that #StandWithUkraine.

- Repo: https://github.com/rejifald/StitchAPI
- StitchAPI is a typed, streaming-first TypeScript toolkit for calling, validating and composing APIs.

Слава Україні! 🇺🇦